### PR TITLE
Fix bug on `_RenderPlainRect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+* Fix a bug on `_RenderPlainRect`'s `computeDryLayout`
+
 ## 0.0.1
 
 * Initial version.

--- a/lib/no_shimmer.dart
+++ b/lib/no_shimmer.dart
@@ -153,7 +153,7 @@ class _RenderPlainRect extends RenderBox {
   @override
   Size computeDryLayout(BoxConstraints constraints) {
     final desiredWidth = width ?? constraints.maxWidth;
-    final desiredHeight = height ?? constraints.maxWidth;
+    final desiredHeight = height ?? constraints.maxHeight;
     final desiredSize = Size(desiredWidth, desiredHeight);
     return constraints.constrain(desiredSize);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: no_shimmer
 description: A simple colored box widget, typically used for showing loading indicator. This is the opposite of shimmer, which has no animation/effects.
-version: 0.0.1
+version: 0.0.2
 repository: https://github.com/iandis/no_shimmer
 issue_tracker: https://github.com/iandis/no_shimmer/issues
 homepage: https://github.com/iandis/no_shimmer


### PR DESCRIPTION
`computeDryLayout` should return max constraints of width x height, not width x width